### PR TITLE
fix d2 error where you can't get some team's schedules

### DIFF
--- a/R/all_functions.R
+++ b/R/all_functions.R
@@ -1436,9 +1436,9 @@ get_team_schedule <-
       return(data.frame())
     }
 
-
-    #New
     df <- df[seq(1,nrow(df), by = 2),]
+    df <- df[!is.na(df$Opponent),]
+
 
     game_ids <-
       unlist(stringr::str_extract_all(html, "(?<=contests/)\\d+(?=[/])"))


### PR DESCRIPTION
I just took out rows with `NA` opponents and it fixed the issue. See (https://github.com/jflancer/bigballR/issues/34)