### PR TITLE
Fix issue where get_date_games() removes team State

### DIFF
--- a/R/all_functions.R
+++ b/R/all_functions.R
@@ -1286,12 +1286,12 @@ get_date_games <-
     url2 <-
       paste0("http://stats.ncaa.org/contests/", id_found, "/box_score")
 
-    # Clean team names
-    home_name = gsub(" [(].*[)]","", home_team)
+    # Clean team names (remove records, like "Rutgers (1-0)")
+    home_name = gsub(" [(][0-9].*[)]","", home_team)
     home_wins = as.vector(stringr::str_extract_all(home_team, "(?<=[(])\\d+(?=-)", T))
     home_losses = as.vector(stringr::str_extract_all(home_team, "(?<=-)\\d+(?=[)])", T))
 
-    away_name = gsub(" [(].*[)]","", away_team)
+    away_name = gsub(" [(][0-9].*[)]","", away_team)
     away_wins = as.vector(stringr::str_extract_all(away_team, "(?<=[(])\\d+(?=-)", T))
     away_losses = as.vector(stringr::str_extract_all(away_team, "(?<=-)\\d+(?=[)])", T))
 
@@ -1363,7 +1363,7 @@ get_date_games <-
     }
 
     return(game_data)
-}
+  }
 
 #' Team Schedule Scrape
 #'


### PR DESCRIPTION
`get_date_games()` was accidentally removing team locations from the end of team names. For example, "Notre Dame (OH) (0-0)" was being shortened to "Notre Dame" instead of "Notre Dame (OH)".