### PR TITLE
Schedule PPD issue fix

### DIFF
--- a/R/all_functions.R
+++ b/R/all_functions.R
@@ -1646,7 +1646,7 @@ get_team_schedule <-
     # add NA game_ids for cancelled games
     new_game_ids <- rep(NA, nrow(df))
     if (length(game_ids) > 0) {
-      new_game_ids[is.na(detail) | detail != 'Canceled'][1:length(game_ids)] <- game_ids
+      new_game_ids[is.na(detail) | !(detail %in% c("Ppd","Canceled"))][1:length(game_ids)] <- game_ids
     }
 
     #Put everything together into tidy data frame


### PR DESCRIPTION
Schedule error that impacts games that are postponed (mainly impacts 2020-2022 seasons)

Those games aren't assigned a Game ID, but the `get_team_schedule` doesn't exclude postponed games when adding IDs back to the data frame. What this means is that every game after the postponed game will show one opponent, but that game ID is one row off from the ID that matches the game against that opponent.

If that doesn't make sense, check this code to see what I mean for an example

```r
schedule = bigballR::get_team_schedule(team.name="Rutgers",season="2021-22",use_chromote = T)
pbp = bigballR::get_play_by_play(schedule$Game_ID)

output = schedule |> 
  dplyr::mutate(opp = if_else(Home=="Rutgers",Away,Home)) |> 
  dplyr::left_join((pbp |> 
               dplyr::group_by(ID) |> 
               dplyr::summarise(pbp_opp = if_else(first(Home)=="Rutgers",
                                           first(Away),first(Home)))),
            join_by(Game_ID==ID)) |> 
  dplyr::mutate(mismatch = if_else(opp!=pbp_opp,"MISMATCH",""))
```
This causes no issues when running the schedule IDs through the `get_play_by_play` function, but will cause issues if using the schedule IDs to join other game info together (like I did when using schedule IDs to see if I had corresponding PBP)